### PR TITLE
cont-lib-changed: use 'container-' prefix

### DIFF
--- a/containers/pg-cont.yaml
+++ b/containers/pg-cont.yaml
@@ -35,12 +35,12 @@ parts:
       - type: shell
         action: "systemctl enable postgresql-container.service"
       # For the default PostgreSQL container, we'll start cont-postgresql-cmd
-      # binary when cont-entry is executed.  Layers above us should replace
-      # this symlink!
+      # binary when container-entrypoint is executed.  Layers above us should
+      # replace this symlink!
       - type: shell
-        action: !eval '"ln -s {0}/cont-postgresql-cmd {0}/cont-start".format(dirs["bindir"])'
+        action: !eval '"ln -s {0}/cont-postgresql-cmd {0}/container-start".format(dirs["bindir"])'
 
   footer:
     entry:
-    - !eval '"{0}/cont-entry".format(dirs["bindir"])'
+    - !eval '"{0}/container-entrypoint".format(dirs["bindir"])'
     user: postgres

--- a/libexec/preexec.in
+++ b/libexec/preexec.in
@@ -37,7 +37,7 @@ test -f "$pidfile" \
         "seems like another PostgreSQL server uses DB data because" \
         "the file '$pidfile' already exists.  If you are" \
         "sure that the pidfile is leftover, use 'clear_pgdata_pidfile'" \
-        "option (see 'cont-help' for more info)" \
+        "option (see 'container-usage' for more info)" \
     && exit 1
 
 # Run the checking script here manually, usually placed in ExecStartPre=.

--- a/share/cont-postgresql/cont-postgresql.sh.in
+++ b/share/cont-postgresql/cont-postgresql.sh.in
@@ -146,7 +146,7 @@ pgcont_check_external_storage()
 You plan to run the data directory '$pgdata' from container.  Please run the
 image like 'docker run -v YOUR_DIR:$pgdata'.  Or use the
 'assert_external_data = false' option in POSTGRESQL_CONTAINER_OPTS.  For more
-info see the 'cont-help' command output."
+info see the 'container-usage' command output."
 
     test -f "$pgdata/.container_internal" \
         && cont_error "$msg" \


### PR DESCRIPTION
See https://github.com/sclorg/rhscl2dockerfile/pull/11
- containers/pg-cont.yaml: Fix comment to mention right script.
- libexec/preexec.in (parts.footer.entry): Use right binary as
  the entrypoint.  TODO: Don't we want to generate it automatically?
